### PR TITLE
feat: email regex checker utility

### DIFF
--- a/Src/Exceptions/ExceptionEmail.cs
+++ b/Src/Exceptions/ExceptionEmail.cs
@@ -1,0 +1,11 @@
+namespace ExceptionEmail
+{
+    public class EmailException : Exception
+    {
+        public EmailException()
+        { }
+
+        public EmailException(string message) : base(message)
+        { }
+    }
+}

--- a/Src/Utilities/UtilEmail.cs
+++ b/Src/Utilities/UtilEmail.cs
@@ -1,0 +1,18 @@
+using System.Text.RegularExpressions;
+using ExceptionEmail;
+
+namespace UtilEmail
+{
+    public class EmailUtil
+    {
+        public static void CheckEmailAddress(string email)
+        {
+            string emailRegex = @"^[a-z]{1}[a-z0-9\-_.]+[a-z0-9]{1}@[a-z0-9]{1}[a-z0-9_\.]+[a-z0-9]{1}\.[a-z.]+[a-z]{1}$";
+
+            if (!Regex.IsMatch(email, emailRegex))
+            {
+                throw new EmailException("error: this email address doesn't matches the required format");
+            }
+        }
+    }
+}


### PR DESCRIPTION
- except: email exception created
- feat: email utility for check with regex

I just created the exception generic for email errors checker and I use the regex to make this check, it not success it throw a new exception to use with the error message.